### PR TITLE
FutureBuilder's onFailure works now.

### DIFF
--- a/lib/src/core/builders/dui_future_builder.dart
+++ b/lib/src/core/builders/dui_future_builder.dart
@@ -91,7 +91,7 @@ Future<Object?> _makeFuture(
             enclosing: ExprContext(variables: {'response': value.data}));
       }, onError: (e) async {
         final errorAction =
-            ActionFlow.fromJson(future.valueFor(keyPath: 'onError'));
+            ActionFlow.fromJson(future.valueFor(keyPath: 'onFailure'));
         await ActionHandler.instance.execute(
             context: context,
             actionFlow: errorAction,


### PR DESCRIPTION
Changes keyPath from "onError" to "onFailure" to match with ui_schema