### PR TITLE
fix: PageParams Backwards Compatibility fix for 'pageParams.varName'

### DIFF
--- a/lib/src/framework/page/page.dart
+++ b/lib/src/framework/page/page.dart
@@ -53,9 +53,9 @@ class DUIPage extends StatelessWidget {
     final resolvedState = pageDef.initStateDefs?.map((k, v) => MapEntry(
         k,
         DataTypeCreator.create(v,
-            scopeContext: DefaultScopeContext(
-              variables: {...?resolvePageArgs},
-              enclosing: scope,
+            scopeContext: _createExprContext(
+              resolvePageArgs,
+              null,
             ))));
 
     Widget child = StatefulScopeWidget(


### PR DESCRIPTION
 refactor DUIPage to use _createExprContext for initializing state definitions