### PR TITLE
svg color fixes

### DIFF
--- a/lib/src/framework/widgets/image.dart
+++ b/lib/src/framework/widgets/image.dart
@@ -102,7 +102,7 @@ class VWImage extends VirtualLeafStatelessWidget<Props> {
         return SvgPicture.network(
           finalUrl,
           colorFilter:
-              ColorFilter.mode(color ?? Colors.black, BlendMode.srcATop),
+              color != null ? ColorFilter.mode(color, BlendMode.srcIn) : null,
           errorBuilder: (context, error, stackTrace) =>
               _buildErrorWidget(error),
           fit: To.boxFit(props.get('fit')),
@@ -111,7 +111,7 @@ class VWImage extends VirtualLeafStatelessWidget<Props> {
         return SvgPicture.asset(
           imageSource,
           colorFilter:
-              ColorFilter.mode(color ?? Colors.black, BlendMode.srcATop),
+              color != null ? ColorFilter.mode(color, BlendMode.srcIn) : null,
           errorBuilder: (context, error, stackTrace) =>
               _buildErrorWidget(error),
           fit: To.boxFit(props.get('fit')),

--- a/lib/src/framework/widgets/svg.dart
+++ b/lib/src/framework/widgets/svg.dart
@@ -30,7 +30,7 @@ class VWSvgImage extends VirtualLeafStatelessWidget<Props> {
           width: width,
           height: height,
           colorFilter:
-              ColorFilter.mode(color ?? Colors.black, BlendMode.srcATop),
+              color != null ? ColorFilter.mode(color, BlendMode.srcIn) : null,
           errorBuilder: (context, error, stackTrace) =>
               _buildErrorWidget(error),
           fit: To.boxFit(props.get('fit')),
@@ -41,7 +41,7 @@ class VWSvgImage extends VirtualLeafStatelessWidget<Props> {
           width: width,
           height: height,
           colorFilter:
-              ColorFilter.mode(color ?? Colors.black, BlendMode.srcATop),
+              color != null ? ColorFilter.mode(color, BlendMode.srcIn) : null,
           errorBuilder: (context, error, stackTrace) =>
               _buildErrorWidget(error),
           fit: To.boxFit(props.get('fit')),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue where SVG images defaulted to an unintended black tint when no color was specified.
  * Improved SVG tinting behavior: when a color is provided, tint is applied more accurately for both asset and network SVGs, enhancing visual fidelity and consistency.
  * No changes to public APIs; behavior is now more predictable for images without explicit color settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->