### PR TITLE
fix: Remove hasIndicatorDecoration flag

### DIFF
--- a/lib/src/framework/widgets/tab_view/tab_bar.dart
+++ b/lib/src/framework/widgets/tab_view/tab_bar.dart
@@ -50,9 +50,7 @@ class VWTabBar extends VirtualStatelessWidget<Props> {
                 : TabAlignment.center
             : null,
         indicatorSize: indicatorSize,
-        indicator: props.getBool('hasIndicatorDecoration') ?? false
-            ? _buildIndicatorDecoration(payload)
-            : null,
+        indicator: _buildIndicatorDecoration(payload),
         controller: controller,
         overlayColor: WidgetStateProperty.all(Colors.transparent),
         padding: To.edgeInsets(props.get('tabBarPadding')),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined TabBar indicator rendering logic for improved consistency.
  * No changes to public APIs or expected behavior.

* **Bug Fixes**
  * Ensures tab indicator rendering is handled uniformly across render paths.

* **Chores**
  * Internal cleanup related to indicator handling; no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->