### PR TITLE
[DG-105] obscureText property is now dynamic in the textformfield

### DIFF
--- a/lib/src/framework/widgets/text_form_field.dart
+++ b/lib/src/framework/widgets/text_form_field.dart
@@ -39,6 +39,9 @@ class VWTextFormField extends VirtualStatelessWidget<Props> {
     final maxLines = props.getInt('maxLines');
     final minLines = props.getInt('minLines');
     final maxLength = props.getInt('maxLength');
+    final effectiveMaxLines = obscureText ? 1 : maxLines;
+    final effectiveMinLines = obscureText ? 1 : minLines;
+    final isMultiline = (effectiveMinLines ?? 1) > 1;
     final fillColor = payload.evalColor(props.get('fillColor'));
     final labelText = payload.eval<String>(props.get('labelText'));
     final labelStyle = payload.getTextStyle(props.getMap('labelStyle'));
@@ -91,8 +94,8 @@ class VWTextFormField extends VirtualStatelessWidget<Props> {
       keyboardType: keyboardType,
       textInputAction: textInputAction,
       style: style,
-      maxLines: maxLines,
-      minLines: minLines,
+      maxLines: effectiveMaxLines, // Ensuring the effective maxLines and minLines are dynamically set as per the obscureText
+      minLines: effectiveMinLines,
       maxLength: maxLength,
       cursorColor: cursorColor,
       validations: validations,
@@ -104,9 +107,7 @@ class VWTextFormField extends VirtualStatelessWidget<Props> {
         errorStyle: errorStyle,
         hintText: hintText,
         hintStyle: hintStyle,
-        contentPadding: minLines != null
-            ? (minLines > 1 ? const EdgeInsets.all(12) : contentPadding)
-            : contentPadding,
+        contentPadding: isMultiline ? const EdgeInsets.all(12) : contentPadding,
         focusColor: focusColor,
         prefixIcon: childOf('prefix')?.toWidget(payload),
         suffixIcon: childOf('suffix')?.toWidget(payload),


### PR DESCRIPTION
- change obscureText from static boolean to dynamic expression support
- using renderPayload for runtime evaluation and better flexibility
Issue resolved : - Make 'Obscure text' property dynamic in TextField